### PR TITLE
Turbulence Stencil fixes to verify with `gtc:gt:gpu` backend

### DIFF
--- a/turb/python/stencils/turb_stencils.py
+++ b/turb/python/stencils/turb_stencils.py
@@ -1714,87 +1714,6 @@ def mfpblt(
         domain=(im, 1, kmpbl),
     )
 
-    # if BACKEND=="gtc:gt:cpu_ifirst":
-    #     file = open("qcko.out","wb")
-    #     np.save(file,qcko)
-    #     file.close()
-
-    #     file = open("zl.out","wb")
-    #     np.save(file,zl)
-    #     file.close()
-
-    #     file = open("q1.out","wb")
-    #     np.save(file,q1_gt)
-    #     file.close()
-
-    #     file = open("cnvflg.out","wb")
-    #     np.save(file,cnvflg)
-    #     file.close()
-
-    #     file = open("kpbl.out","wb")
-    #     np.save(file,kpbl)
-    #     file.close()
-
-    #     file = open("xlamue.out","wb")
-    #     np.save(file,xlamue)
-    #     file.close()
-
-    # if BACKEND == "gtc:gt:gpu":
-    #     file = open("qcko.out","rb")
-    #     qcko_cpu = np.load(file)
-    #     file.close()
-
-    #     qcko_gpu = np.zeros((qcko.shape))
-    #     qcko_gpu[:,:,:,:] = qcko[:,:,:,:]
-
-    #     np.testing.assert_allclose(qcko_cpu, qcko_gpu, equal_nan=True)
-
-
-    #     file = open("zl.out","rb")
-    #     zl_cpu = np.load(file)
-    #     file.close()
-
-    #     zl_gpu = np.zeros((zl.shape))
-    #     zl_gpu[:,:,:] = zl[:,:,:]
-
-    #     np.testing.assert_allclose(zl_cpu, zl_gpu, equal_nan=True)
-
-    #     file = open("q1.out","rb")
-    #     q1_cpu = np.load(file)
-    #     file.close()
-
-    #     q1_gpu = np.zeros((q1_gt.shape))
-    #     q1_gpu[:,:,:,:] = q1_gt[:,:,:,:]
-
-    #     np.testing.assert_allclose(q1_cpu, q1_gpu, equal_nan=True)
-
-    #     file = open("cnvflg.out","rb")
-    #     cnvflg_cpu = np.load(file)
-    #     file.close()
-
-    #     cnvflg_gpu = np.zeros((cnvflg.shape),dtype=bool)
-    #     cnvflg_gpu[:,:] = cnvflg[:,:]
-
-    #     np.testing.assert_allclose(cnvflg_cpu, cnvflg_gpu, equal_nan=True)
-
-    #     file = open("kpbl.out","rb")
-    #     kpbl_cpu = np.load(file)
-    #     file.close()
-
-    #     kpbl_gpu = np.zeros((kpbl.shape),dtype=int)
-    #     kpbl_gpu[:,:] = kpbl[:,:]
-
-    #     np.testing.assert_allclose(kpbl_cpu, kpbl_gpu, equal_nan=True)
-
-    #     file = open("xlamue.out","rb")
-    #     xlamue_cpu = np.load(file)
-    #     file.close()
-
-    #     xlamue_gpu = np.zeros(xlamue.shape)
-    #     xlamue_gpu[:,:,:] = xlamue[:,:,:]
-
-    #     np.testing.assert_allclose(xlamue_cpu, xlamue_gpu, equal_nan=True)
-
     mfpblt_s3(
         cnvflg = cnvflg,
         kpbl = kpbl,
@@ -1808,27 +1727,10 @@ def mfpblt(
         domain=(im, 1, kmpbl)
     )
 
-    # if BACKEND=="gtc:gt:cpu_ifirst":
-    #     file = open("qcko.out","wb")
-    #     np.save(file,qcko)
-    #     file.close()
-
-
-    # if BACKEND=="gtc:gt:gpu":
-    #     file = open("qcko.out","rb")
-    #     qcko_cpu = np.load(file)
-    #     file.close()
-
-    #     qcko_gpu = np.zeros((qcko.shape))
-    #     qcko_gpu[:,:,:,:] = qcko[:,:,:,:]
-
-    #     np.testing.assert_allclose(qcko_cpu, qcko_gpu, equal_nan=True)
-
-
     return kpbl, hpbl, buo, xmf, tcko, qcko, ucko, vcko, xlamue
 
 
-@gtscript.stencil(backend=backend,skip_passes=["graph_merge_horizontal_executions","GreedyMerging"])#,,"KCacheDetection", "FillFlushToLocalKCaches","IJCacheDetection","PruneKCacheFills","PruneKCacheFlushes", "OnTheFlyMerging","MaskInlining","MaskStmtMerging","NoFieldAccessPruning","RemoveUnexecutedRegions","LocalTemporariesToScalars","WriteBeforeReadTemporariesToScalars","AdjacentLoopMerging"])
+@gtscript.stencil(backend=backend,skip_passes=["graph_merge_horizontal_executions","GreedyMerging"])
 def mfpblt_s3(
     cnvflg : FIELD_BOOL_IJ,
     kpbl : FIELD_INT_IJ,
@@ -2494,21 +2396,6 @@ def mfscu(
         domain=(im, 1, kmscu),
     )
 
-    # if BACKEND=="gtc:gt:cpu_ifirst":
-    #     file = open("qcdo.out","wb")
-    #     np.save(file,qcdo)
-    #     file.close()
-
-    # if BACKEND=="gtc:gt:gpu":
-    #     file = open("qcdo.out","rb")
-    #     qcdo_cpu = np.load(file)
-    #     file.close()
-
-    #     qcdo_gpu = np.zeros(qcdo.shape)
-    #     qcdo_gpu[:,:,:,:] = qcdo[:,:,:,:]
-
-    #     np.testing.assert_allclose(qcdo_cpu, qcdo_gpu, equal_nan=True)
-
     mfscu_10(
         cnvflg = cnvflg,
         krad = krad,
@@ -2522,21 +2409,6 @@ def mfscu(
         ntrac1 = ntrac1,
         domain = (im, 1, kmscu),
     )
-
-    # if BACKEND=="gtc:gt:cpu_ifirst":
-    #     file = open("qcdo.out","wb")
-    #     np.save(file,qcdo)
-    #     file.close()
-
-    # if BACKEND=="gtc:gt:gpu":
-    #     file = open("qcdo.out","rb")
-    #     qcdo_cpu = np.load(file)
-    #     file.close()
-
-    #     qcdo_gpu = np.zeros(qcdo.shape)
-    #     qcdo_gpu[:,:,:,:] = qcdo[:,:,:,:]
-
-    #     np.testing.assert_allclose(qcdo_cpu, qcdo_gpu, equal_nan=True) 
 
     return radj, mrad, buo, xmfd, tcdo, qcdo, ucdo, vcdo, xlamde
 


### PR DESCRIPTION
Fixes to `turb_stencil.py` that enable the turbulence stencil standalone to verify with the `gtc:gt:gpu` backend.